### PR TITLE
Adjust orientation of trunk to follow alpha0 during takeoff

### DIFF
--- a/script/tests/spiderman_city1_path.py
+++ b/script/tests/spiderman_city1_path.py
@@ -160,6 +160,8 @@ pp.displayPath(solutionPathId, [0.0, 0.0, 0.8, 1.0])
 rbprmBuilder.rotateAlongPath (solutionPathId)
 orientedpathId = ps.numberPaths () - 1
 #pp(orientedpathId)
+r(pp.client.problem.configAtParam(orientedpathId,0))
+
 
 V0list = rbprmBuilder.getsubPathsV0Vimp("V0",solutionPathId)
 Vimplist = rbprmBuilder.getsubPathsV0Vimp("Vimp",solutionPathId)

--- a/script/tests/spiderman_city_interp.py
+++ b/script/tests/spiderman_city_interp.py
@@ -82,7 +82,7 @@ fullConfSize = len(fullBody.getCurrentConfig()) # with or without ECS in fullbod
 q_init = fullBody.getCurrentConfig(); q_goal = q_init [::]
 
 # WARNING: q_init and q_goal may have changed in orientedPath
-entryPathId = tp.solutionPathId # tp.orientedpathId
+entryPathId = tp.orientedpathId # tp.orientedpathId
 trunkPathwaypoints = ps.getWaypoints (entryPathId)
 q_init[0:confsize] = trunkPathwaypoints[0][0:confsize]
 q_goal[0:confsize] = trunkPathwaypoints[len(trunkPathwaypoints)-1][0:confsize]


### PR DESCRIPTION
When _rotateAlongPath_ is called, it adjust the Z axis of the trunk to follow the alpha0 orientation before the jump. This give more realistic movement on humanoid. 

Need to be tested on other kind of character, may be add a parameter to turn this OFF ?
